### PR TITLE
Provide some better error messaging for common errors.

### DIFF
--- a/ecr-login.go
+++ b/ecr-login.go
@@ -79,7 +79,7 @@ func getRegistryIds() []*string {
 func main() {
 	// configure aws client
 	sess := session.New()
-	svc := ecr.New(sess, aws.NewConfig().WithRegion(getRegion(sess)))
+	svc := ecr.New(sess, aws.NewConfig().WithMaxRetries(10).WithRegion(getRegion(sess)))
 
 	// this lets us handle multiple registries
 	params := &ecr.GetAuthorizationTokenInput{

--- a/ecr-login.go
+++ b/ecr-login.go
@@ -2,14 +2,16 @@ package main
 
 import (
 	"encoding/base64"
-	"github.com/rlister/ecr-login/Godeps/_workspace/src/github.com/aws/aws-sdk-go/aws"
-	"github.com/rlister/ecr-login/Godeps/_workspace/src/github.com/aws/aws-sdk-go/aws/ec2metadata"
-	"github.com/rlister/ecr-login/Godeps/_workspace/src/github.com/aws/aws-sdk-go/aws/session"
-	"github.com/rlister/ecr-login/Godeps/_workspace/src/github.com/aws/aws-sdk-go/service/ecr"
+	"fmt"
 	"os"
 	"strings"
 	"text/template"
 	"time"
+
+	"github.com/rlister/ecr-login/Godeps/_workspace/src/github.com/aws/aws-sdk-go/aws"
+	"github.com/rlister/ecr-login/Godeps/_workspace/src/github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/rlister/ecr-login/Godeps/_workspace/src/github.com/aws/aws-sdk-go/aws/session"
+	"github.com/rlister/ecr-login/Godeps/_workspace/src/github.com/aws/aws-sdk-go/service/ecr"
 )
 
 type Auth struct {
@@ -53,7 +55,10 @@ func getRegion(sess *session.Session) string {
 	region, exists := os.LookupEnv("AWS_REGION")
 	if !exists {
 		ec2region, err := ec2metadata.New(sess).Region()
-		check(err)
+		if err != nil {
+			fmt.Printf("AWS_REGION not set and unable to fetch region from instance metadata: %s\n", err.Error())
+			os.Exit(1)
+		}
 		region = ec2region
 	}
 	return region
@@ -83,7 +88,10 @@ func main() {
 
 	// request the token
 	resp, err := svc.GetAuthorizationToken(params)
-	check(err)
+	if err != nil {
+		fmt.Printf("Error authorizing: %s\n", err.Error())
+		os.Exit(1)
+	}
 
 	// fields to send to template
 	fields := make([]Auth, len(resp.AuthorizationData))


### PR DESCRIPTION
We're using ecr-login as a standard tool for our engineers to interface with ECR. Rather than showing them stack traces for some common mistakes like undefined AWS_REGION, this patch gives a nicer error message. I've still left in the panics for helping diagnose less common errors that could happen.
