### PR TITLE
Remove -e flag to docker login

### DIFF
--- a/ecr-login.go
+++ b/ecr-login.go
@@ -30,7 +30,7 @@ func check(e error) {
 }
 
 // default template prints docker login command
-const DEFAULT_TEMPLATE = `{{range .}}docker login -u {{.User}} -p {{.Pass}} -e none {{.ProxyEndpoint}}
+const DEFAULT_TEMPLATE = `{{range .}}docker login -u {{.User}} -p {{.Pass}} {{.ProxyEndpoint}}
 {{end}}`
 
 // load template from file or use default


### PR DESCRIPTION
This flag is no longer supported.  Supplying it will result in a failure.

Fixes #6.