### PR TITLE
Add support for RKT ECR auth

### DIFF
--- a/templates/rktv1cfg.tmpl
+++ b/templates/rktv1cfg.tmpl
@@ -1,0 +1,11 @@
+{{range $index, $a := .}}{
+  "rktKind": "dockerAuth",
+  "rktVersion": "v1",
+  "registries": [
+    "{{$a.ProxyEndpoint}}"
+  ],
+  "credentials": {
+    "user": "AWS",
+    "password": "{{$a.Token}}"
+  }
+}{{end}}


### PR DESCRIPTION
This enables us to switch kubelet from a public to a private image.

File format is here: https://github.com/rkt/rkt/issues/3157